### PR TITLE
Fix/ acts_as_heir not copying validations options

### DIFF
--- a/lib/cti/active_record/acts_as_heir.rb
+++ b/lib/cti/active_record/acts_as_heir.rb
@@ -45,7 +45,7 @@ module Cti
         
         # Include validations from the predecessor
           self._predecessor_klass.validators.each do |validator|
-            self.validates_with(validator.class, :attributes => validator.attributes, :options => validator.options)
+            self.validates_with(validator.class, validator.options.dup.merge({attributes: validator.attributes}))
           end
 
         # Expose methods from predecessor


### PR DESCRIPTION
Previously when an object declared itself a child of a parent it did not copy the validations correctly and that caused the options of the validations to be lost. This fix copies the options correctly.
